### PR TITLE
feat(extractor): support anime1.pw direct video sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- 支援 `anime1.pw` 單集、`?cat=` 分類頁與 slug 分類頁下載；此來源直接解析頁面 MP4 source，沿用現有 Range 續傳下載流程。
+
+### Changed
+
+- `anime1.pw` 頁面解析改用 GET 抓取 HTML，避免依賴 WordPress / Cloudflare 對 POST 頁面請求的相容行為。
+- direct video parser 會優先選擇 `video/mp4` source；若頁面提供多個 source 會記錄 warning。
+
+### Fixed
+
+- 分類頁 HTML 無法解析出 episode link 時改為回報 `ParseError`，避免 selector 失效時 silent 回傳 0 集。
+
 ## 0.1.0 - 2026-05-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,208 @@
+# Contributing
+
+AniCat-v2 是一個 CLI 下載工具，不是一次性的腳本集合。任何改動都應該維持清楚的模組邊界、可測試性與可重現的 release 流程。
+
+## 專案結構
+
+```txt
+.
+├── src/anicat/
+│   ├── cli.py                  # CLI 參數、輸出、exit code
+│   ├── service.py              # URL 展開、併發下載協調、錯誤隔離
+│   ├── client.py               # HTTP session、timeout、retry、page/API/video request
+│   ├── extractor.py            # provider routing、HTML/API parser
+│   ├── downloader.py           # Range 續傳、Content-Range 驗證、原子寫入
+│   ├── progress.py             # Rich 進度列
+│   ├── options.py              # options 與 validation
+│   ├── models.py               # domain models / progress events
+│   ├── urls.py                 # URL classification / source detection / dedupe
+│   ├── constants.py            # package metadata / default values
+│   ├── errors.py               # domain-specific exceptions
+│   ├── logging_config.py       # logging level 與 handler 設定
+│   └── py.typed                # PEP 561 typed package marker
+├── tests/                      # 單元測試與 opt-in integration smoke test
+├── .github/workflows/ci.yml    # CI quality gate
+├── .pre-commit-config.yaml     # Pre-commit Hooks
+├── pyproject.toml
+├── poetry.lock
+├── CHANGELOG.md
+├── README.md
+└── CONTRIBUTING.md
+```
+
+## 開發環境
+
+- 需求：
+
+  - Python `>=3.12,<4.0`
+  - Poetry
+
+- 安裝：
+
+   ```bash
+   poetry install --with dev
+   poetry run pre-commit install
+   ```
+
+- 常用檢查：
+
+   ```bash
+   poetry run ruff format --check .
+   poetry run ruff check .
+   poetry run pyright
+   poetry run python -m unittest
+   poetry run python -m compileall src/anicat tests
+   poetry check
+   ```
+
+- 完整 pre-commit：
+
+   ```bash
+   poetry run pre-commit run --all-files
+   ```
+
+## 設計原則
+
+- **CLI 保持薄**：`cli.py` 只處理參數、輸出與 exit code，不放下載邏輯。
+- **Service 負責協調**：`service.py` 負責 URL 展開、併發、client lifecycle 與錯誤隔離。
+- **Extractor 只解析**：`extractor.py` 負責把頁面/API response 轉成 `Episode`，不做檔案寫入。
+- **Downloader 不知道 Anime1**：`downloader.py` 只處理 stream、Range、`.part`、驗證與檔案輸出。
+- **Client 只做 HTTP**：`client.py` 不放 parser 邏輯，也不決定下載檔名。
+- **依賴反轉**：跨模組互動優先用 `Protocol` 或清楚的 domain model，不讓測試依賴真實網路。
+- **小 Patch 優先**：不要把 bug fix、重構、文件改寫、release 準備混在同一個 commit。
+
+## 新增或修改 Provider
+
+> 不要把新網域當成舊網域 alias 硬塞。先判斷來源的下載模型：
+
+| 模型 | 處理方式 |
+|---|---|
+| direct MP4 | 可沿用目前 downloader |
+| API 回傳 MP4 | 新增 provider-specific extractor |
+| HLS / m3u8 | 需要新的 HLS backend，不要塞進 MP4 downloader |
+
+新增 Provider 時至少要補：
+
+- URL classification tests
+- parser unit tests
+- service / downloader 邊界測試
+- README 支援來源表格
+- CHANGELOG
+
+真實網站測試必須是 opt-in smoke test，不進預設 CI。
+
+## 測試策略
+
+- 預設測試不能依賴外部網站。
+
+   ```bash
+   poetry run python -m unittest
+   ```
+
+- 真實 Anime1 smoke test 只在手動指定 env var 時執行：
+
+   ```bash
+   ANICAT_RUN_INTEGRATION=1 poetry run python -m unittest tests.test_integration_smoke
+   ANICAT_RUN_PW_INTEGRATION=1 poetry run python -m unittest tests.test_integration_smoke
+   ```
+
+- 測試要求：
+
+   - parser 測試用手寫 HTML fixture 覆蓋 selector 與 edge cases。
+   - downloader 測試必須覆蓋 resume、Range、`Content-Range`、server 忽略 Range、incomplete stream。
+   - CLI 測試要覆蓋 exit code 與非 TTY 行為。
+   - 新增 options 時要補 validation tests。
+   - 若要加入真實 HTML fixture，只保留 parser 必要 DOM 片段，不提交整頁 response、cookie、短期 token 或下載影片。
+
+## 程式風格
+
+- 使用型別註記，並讓 `pyright` standard 通過。
+- 使用 `ruff format`，不要手動套不同格式風格。
+- 避免過度抽象；等第三個 provider 或重複 pattern 明確出現再抽共用基底。
+- 不用一個字母變數名，除非是非常局部且語意明確的數學/迭代場景。
+- 不新增 license/copyright header。
+
+## 文件更新規則
+
+以下改動需要同步更新文件：
+
+| 改動 | 需要更新 |
+|---|---|
+| 新 CLI 參數 | `README.md` 常用參數 / 常用指令 |
+| 新支援來源 | `README.md` 支援來源 |
+| 使用者可見 bug fix | PR 說明的 release note 摘要 |
+| 新 release | 維護者於 release 前更新 `pyproject.toml`、`CHANGELOG.md`、`README.md` |
+
+> 一般 PR 不需要直接修改 `CHANGELOG.md`。`CHANGELOG.md` 是 release artifact，由維護者在 RC / release 前根據已合併 PR 統一整理。
+
+## Commit 與 PR
+
+使用 Conventional Commits：
+
+```text
+feat: add anime1.pw direct source support
+fix: reject invalid anime1.pw system paths
+test: cover direct MP4 source selection
+docs: refresh README installation guide
+chore: prepare release candidate
+refactor: split provider-specific extractors
+```
+
+PR 說明至少包含：
+
+- 改了什麼
+- 為什麼改
+- 怎麼驗證
+- 是否影響 CLI / README
+- 是否需要 migration
+- 使用者可見改動的 release note 摘要
+
+## Release 流程
+
+RC / release 前確認：
+
+1. 更新 `pyproject.toml` 版本。
+2. 更新 `CHANGELOG.md`。
+3. 更新 `README.md` 的 release tag 安裝指令。
+4. 跑完整品質門檻：
+
+   ```bash
+   poetry run ruff format --check .
+   poetry run ruff check .
+   poetry run pyright
+   poetry run python -m unittest
+   poetry run python -m compileall src/anicat tests
+   poetry check
+   poetry build
+   ```
+
+5. 需要時跑 opt-in smoke test。
+6. Commit release prep。
+7. 建立 tag，例如：
+
+   ```bash
+   git tag v0.2.0-rc.1
+   git push origin main --tags
+   ```
+
+8. GitHub Release 勾選 pre-release（如果是 RC）。
+
+版本規則：
+
+- Git tag 使用 SemVer / RC 樣式：`v0.2.0-rc.1`
+- Python package version 使用 PEP 440：`0.2.0rc1`
+
+## 不要提交
+
+- 下載下來的影片。
+- `.part` 暫存檔。
+- cookie、token、API key。
+- 含短期簽名的完整真實 response。
+- build/cache 產物，例如 `dist/`、`.ruff_cache/`、`__pycache__/`。
+
+## 安全邊界
+
+- 不繞過站方驗證或存取控制。
+- 不提交可重放的私密 token / cookie。
+- 不把 HLS playlist token 寫進 repo。
+- 對外部網站的測試必須 opt-in，避免 CI 依賴第三方服務。

--- a/README.md
+++ b/README.md
@@ -2,113 +2,116 @@
 
 > 穩定、快速、可續傳的 Anime1 命令列下載器。
 
-AniCat-v2 可以把 Anime1 的單集或季度連結下載成乾淨的本機 MP4 檔案。這版已經不是單檔腳本雛形，而是具備套件化核心、型別檢查、離線測試、CI 與 Rich 多任務進度列的下載工具。
+AniCat-v2 是一個專注於 Anime1 下載體驗的 CLI 工具。它可以把單集、分類、季度或多個 URL 解析成乾淨的本機 MP4 檔案，並提供併發下載、`.part` 續傳、Rich 多任務進度列、串流中斷重試與安全檔名處理。
+
 
 ## 特色
 
-- **支援單集與季度下載**：可輸入單集 URL、分類/季度 URL，也支援多 URL 批次下載。
+- **支援單集與季度下載**：可輸入 `anime1.me` / `anime1.pw` 單集 URL、分類/季度 URL，也支援多 URL 批次下載。
 
 - **併發下載**：用 `--concurrency` 控制同時下載數，整季下載更有效率。
 
 - **Rich 多任務進度列**：顯示整體下載量、速度、完成集數，以及目前下載中的單檔進度。
 
-- **預設支援續傳**：中斷時保留 `*.mp4.part` 暫存檔，下次執行會接續下載。
+- **預設支援續傳**：預設沿用 `.mp4.part` 暫存檔接續下載。
 
-- **串流中斷自動續傳**：下載途中斷線會用 Range request 重試，並驗證 `Content-Range` 避免錯誤 append。
+- **串流中斷重試**：使用 Range request 重新接續，並驗證 `Content-Range`。
 
-- **原子寫入**：下載完成後才轉成 `.mp4`，避免未完成檔案被誤認成完整影片。
+- **支援來源**
 
-- **安全檔名處理**：自動清理跨平台非法字元與 Windows 保留名稱。
+    | 來源 | 單集 URL | 分類 / 季度 URL | 狀態 |
+    |---|---|---|---|
+    | `anime1.me` | `https://anime1.me/15651` | `https://anime1.me/category/...` | 支援 |
+    | `anime1.pw` | `https://anime1.pw/349` | `https://anime1.pw/?cat=60`、`https://anime1.pw/<slug>` | 支援 |
+    | `anime1.cc` | HLS / m3u8 | HLS / m3u8 | 尚未支援 |
+    | `anime1.in` | HLS / m3u8 | HLS / m3u8 | 尚未支援 |
 
-- **產品級專案結構**：採用 `src/` layout、CLI entry point、型別檢查、單元測試與 CI。
 
-## 快速開始
+## 安裝方式
 
-```bash
-poetry install
-poetry run anicat https://anime1.me/15651
-```
-
-下載整個分類/季度：
-
-```bash
-poetry run anicat https://anime1.me/category/... --output ./Anime1_Download --concurrency 3
-```
-
-多個 URL 可用空白或逗號分隔：
+### A. GitHub Release 安裝（推薦）
 
 ```bash
-poetry run anicat https://anime1.me/15651 https://anime1.me/15603
-poetry run anicat https://anime1.me/15651,https://anime1.me/15603
+python3 -m pip install "git+https://github.com/HeiTang/AniCat-v2.git@v0.2.0-rc.1"
+anicat --help
 ```
 
-### 不使用 Poetry 安裝
+### B. 本機開發安裝
 
-Poetry 是建議的開發與執行方式；若只想用一般 Python 環境安裝：
+- 下載專案
+    
+    ```bash
+    git clone https://github.com/HeiTang/AniCat-v2.git
+    cd AniCat-v2
+    ```
+
+- 安裝套件
+
+    ```bash
+    # 使用 Poetry
+    poetry install
+    poetry run anicat --help
+
+    # 使用一般 Python 環境
+    python3 -m pip install .
+    anicat --help
+    ```
+
+## 使用方法
 
 ```bash
-python3 -m pip install .
-anicat https://anime1.me/15651
+anicat URL [URL ...] [OPTIONS]
 ```
 
-## 常用參數
+### 範例
 
-查看完整說明：
+1. 單集下載：
 
-```bash
-poetry run anicat --help
-```
+    ```bash
+    anicat https://anime1.me/12345
+    ```
 
-常用參數：
+2. 分類 / 季度下載：
+
+    ```bash
+    anicat https://anime1.me/category/your-category-slug
+    anicat https://anime1.pw/your-category-slug
+    ```
+
+3. 多 URL 批次下載：
+
+    ```bash
+    anicat https://anime1.me/12345 https://anime1.me/67890
+    anicat https://anime1.me/12345,https://anime1.me/67890
+    ```
+
+### 常用參數
 
 | 參數 | 說明 | 預設值 |
 |---|---|---|
-| `-o`, `--output DIR` | 指定下載目錄 | `./Anime1_Download` |
+| `-o`, `--output DIR` | 指定輸出資料夾 | `./Anime1_Download` |
 | `-c`, `--concurrency N` | 併發下載數 | `3` |
 | `--timeout SECONDS` | HTTP 讀取逾時秒數 | `30` |
 | `--connect-timeout SECONDS` | HTTP 連線逾時秒數 | `10` |
 | `--retries N` | HTTP 與串流中斷重試次數 | `3` |
 | `--chunk-size BYTES` | 下載分塊大小 | `524288` |
 | `--overwrite` | 覆寫已完成的同名檔案 | `False` |
-| `--no-resume` | 不要沿用既有 `.part` 暫存檔 | `False` |
-| `--no-progress` | 關閉 Rich 進度列，適合只看文字輸出的場景 | `False` |
-| `-v`, `--verbose` | 顯示診斷 log；`-vv` 會顯示 HTTP retry/debug 細節 | `False` |
-| `-q`, `--quiet` | 只保留錯誤等級的診斷 log，下載摘要輸出不受影響 | `False` |
+| `--no-resume` | 不沿用既有 `.part` 暫存檔 | `False` |
+| `--no-progress` | 關閉進度列 | `False` |
+| `-v`, `--verbose` | 顯示診斷 log；`-vv` 顯示 HTTP retry/debug 細節 | `False` |
+| `-q`, `--quiet` | 只保留錯誤等級 log，下載摘要仍會輸出 | `False` |
+| `-V`, `--version` | 顯示版本後離開 | - |
 
-## Exit Codes
-
-| Code | 意義 |
-|---|---|
-| `0` | 全部下載成功，或目標檔案已存在而略過 |
-| `1` | 至少一個 URL 失敗，或沒有找到任何集數 |
-| `2` | CLI 使用方式或參數錯誤，例如沒有輸入 URL |
-
-## 專案架構
-
-```txt
-src/anicat/
-    client.py       # HTTP session、逾時、重試、cookie
-    extractor.py    # Anime1 HTML/API 解析
-    downloader.py   # 續傳、原子寫入、安全檔名
-    service.py      # URL 展開與併發下載協調
-    progress.py     # Rich 多任務進度列
-    cli.py          # 薄 CLI 入口，只處理參數與輸出
-tests/              # 離線單元測試，不依賴 Anime1 網路狀態
+完整參數：
+```bash
+anicat --help
 ```
 
-設計原則：
+## 進階說明
 
-- **CLI 保持輕薄**：CLI 只處理參數與輸出，不放下載業務邏輯。
+### Python API
 
-- **核心可測試**：解析、下載、URL 處理都能用 fixture/mock 離線測試。
-
-- **依賴邊界清楚**：使用 `Protocol` 定義 HTTP 與下載邊界。
-
-- **錯誤彼此隔離**：單集失敗不會拖垮整批下載，最後統一輸出摘要。
-
-## Python API
-
-AniCat-v2 也提供 typed package API：
+除了 CLI，AniCat-v2 也提供 typed package API：
 
 ```python
 from pathlib import Path
@@ -117,44 +120,23 @@ from anicat import AniCatService, DownloadOptions
 
 options = DownloadOptions(output_dir=Path("./Anime1_Download"))
 service = AniCatService(options)
+
 episode_urls = service.collect_episode_urls(["https://anime1.me/15651"])
 reports = service.download_many(episode_urls)
 ```
 
-## 品質檢查
+### Exit Codes
 
-本地與 CI 使用同一組品質門檻：
+| Code | 意義 |
+|---|---|
+| `0` | 全部下載成功，或目標檔案已存在而略過 |
+| `1` | 至少一個 URL 失敗，或沒有找到任何集數 |
+| `2` | CLI 使用方式或參數錯誤，例如沒有輸入 URL |
 
-```bash
-poetry install --with dev
-poetry run ruff format --check .
-poetry run ruff check .
-poetry run pyright
-poetry run python -m unittest
-poetry run python -m compileall src/anicat tests
-poetry check
-```
+## 貢獻
 
-安裝 pre-commit hook：
+歡迎任何形式的貢獻！請先閱讀 [CONTRIBUTING.md](CONTRIBUTING.md) 以了解專案規範與流程。
 
-```bash
-poetry install --with dev
-poetry run pre-commit install
-poetry run pre-commit run --all-files
-```
+## License
 
-真實 Anime1 smoke test 預設不跑，避免 CI 依賴外部網站；需要時手動開啟：
-
-```bash
-ANICAT_RUN_INTEGRATION=1 poetry run python -m unittest tests.test_integration_smoke
-ANICAT_RUN_INTEGRATION=1 ANICAT_SMOKE_URL=https://anime1.me/28979 poetry run python -m unittest tests.test_integration_smoke
-```
-
-GitHub Actions 會在 push / pull request 時執行格式檢查、lint、型別檢查、單元測試與語法編譯檢查。
-
-## 備註
-
-- 單元測試不依賴 Anime1 網路狀態。
-- 真實 Anime1 smoke test 只測解析與 Range contract，不下載完整影片。
-- 版本紀錄見 `CHANGELOG.md`。
-- 若 Anime1 HTML/API 結構改變，優先修 `extractor` 與對應 fixture tests。
+本專案採用 GPL-3.0 License，詳見 [LICENSE](LICENSE) 文件。

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AniCat-v2 是一個專注於 Anime1 下載體驗的 CLI 工具。它可以把單
 ### A. GitHub Release 安裝（推薦）
 
 ```bash
-python3 -m pip install "git+https://github.com/HeiTang/AniCat-v2.git@v0.2.0-rc.1"
+python3 -m pip install "git+https://github.com/HeiTang/AniCat-v2.git@v0.2.0"
 anicat --help
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anicat-v2"
-version = "0.1.0"
+version = "0.2.0"
 description = "Anime1 downloader CLI with resumable concurrent downloads."
 authors = [
     {name = "HeiTang",email = "heitang.me@gmail.com"}

--- a/src/anicat/client.py
+++ b/src/anicat/client.py
@@ -78,6 +78,11 @@ class Anime1Client:
 
         return self.request("POST", url).text
 
+    def get_page(self, url: str) -> str:
+        """Fetch an Anime1 HTML page using a normal browser-style GET method."""
+
+        return self.request("GET", url).text
+
     def post_api(self, data_apireq: str) -> requests.Response:
         """Submit episode API payload and return the raw API response."""
 

--- a/src/anicat/extractor.py
+++ b/src/anicat/extractor.py
@@ -2,20 +2,23 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from http.cookies import CookieError, SimpleCookie
 from typing import Any, Protocol
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup, FeatureNotFound
 
 from .errors import ParseError
 from .models import Episode
+from .urls import ANIME1_ME_SOURCE, ANIME1_PW_SOURCE, SourceKind, source_kind
 
 ACCESS_COOKIE_NAMES = ("e", "p", "h")
 SET_COOKIE_SEPARATOR_PATTERN = re.compile(r",\s*(?=[^=;,\s]+=)")
 LOGGER = logging.getLogger(__name__)
+PageFetcher = Callable[[str], str]
 
 
 @dataclass(frozen=True)
@@ -29,13 +32,32 @@ class SeasonPage:
 class EpisodeSource(Protocol):
     """Minimal HTTP dependency required by Anime1Extractor."""
 
+    def get_page(self, url: str) -> str:
+        """Return raw HTML for an Anime1 page fetched with GET."""
+
+        ...
+
     def post_page(self, url: str) -> str:
-        """Return raw HTML for an Anime1 page."""
+        """Return raw HTML for an Anime1 page fetched with POST."""
 
         ...
 
     def post_api(self, data_apireq: str) -> requests.Response:
         """Return raw response for an Anime1 episode API payload."""
+
+        ...
+
+
+class EpisodeExtractor(Protocol):
+    """Provider-specific extraction behavior selected by Anime1Extractor."""
+
+    def season_episode_urls(self, url: str) -> list[str]:
+        """Collect all episode URLs from a supported season/category URL."""
+
+        ...
+
+    def episode(self, url: str) -> Episode:
+        """Resolve one episode page URL into download-ready metadata."""
 
         ...
 
@@ -71,6 +93,64 @@ def parse_episode_page(html: str) -> tuple[str, str]:
         raise ParseError("episode page is missing title")
 
     return data_apireq, title.get_text(" ", strip=True)
+
+
+def parse_direct_episode_page(html: str, base_url: str) -> tuple[str, str]:
+    """Parse direct-video episode pages that expose a source URL in HTML."""
+
+    soup = parse_html(html)
+    title = soup.select_one("h1.entry-title") or soup.select_one("h2.entry-title")
+    source_url = select_direct_video_source(soup)
+
+    if not title:
+        raise ParseError("episode page is missing title")
+    if source_url is None:
+        raise ParseError("episode page is missing MP4 video source")
+
+    return urljoin(base_url, source_url), title.get_text(" ", strip=True)
+
+
+def select_direct_video_source(soup: BeautifulSoup) -> str | None:
+    """Return the first MP4-compatible direct video source URL."""
+
+    candidates: list[tuple[str, str | None]] = []
+    for source in soup.select("video.video-js source[src]"):
+        source_url = source.get("src")
+        if not isinstance(source_url, str) or not source_url:
+            continue
+        candidates.append((source_url, source_media_type(source_url, source.get("type"))))
+
+    mp4_candidates = [
+        source_url for source_url, source_type in candidates if source_type == "video/mp4"
+    ]
+
+    if len(candidates) > 1:
+        LOGGER.warning(
+            "episode page contains %d source candidates; %d MP4-compatible",
+            len(candidates),
+            len(mp4_candidates),
+        )
+
+    return mp4_candidates[0] if mp4_candidates else None
+
+
+def source_media_type(source_url: str, value: object) -> str | None:
+    """Return the declared media type or infer MP4 from the source URL path."""
+
+    source_type = media_type(value)
+    if source_type is not None:
+        return source_type
+    if urlparse(source_url).path.lower().endswith(".mp4"):
+        return "video/mp4"
+    return None
+
+
+def media_type(value: object) -> str | None:
+    """Normalize a source type attribute into a comparable media type."""
+
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.split(";", 1)[0].strip().lower()
 
 
 def select_episode_api_request(soup: BeautifulSoup) -> str | None:
@@ -161,33 +241,42 @@ def split_combined_set_cookie_header(header: str) -> list[str]:
     return [item.strip() for item in SET_COOKIE_SEPARATOR_PATTERN.split(header) if item.strip()]
 
 
-class Anime1Extractor:
-    """Convert Anime1 HTML/API responses into download-ready domain objects."""
+def collect_paginated_episode_urls(fetch_page: PageFetcher, url: str) -> list[str]:
+    """Collect episode links from a paginated WordPress-style listing."""
+
+    collected: list[str] = []
+    current_url: str | None = url
+    visited: set[str] = set()
+
+    while current_url:
+        if current_url in visited:
+            raise ParseError(f"season pagination loop detected: {current_url}")
+        visited.add(current_url)
+
+        html = fetch_page(current_url)
+        page = parse_season_page(html)
+        if html.strip() and not page.episode_urls:
+            raise ParseError(f"season page returned no episode links: {current_url}")
+        collected.extend(urljoin(current_url, item) for item in page.episode_urls)
+        # Resolve relative pagination URLs against the page that produced them.
+        current_url = urljoin(current_url, page.next_url) if page.next_url else None
+
+    return collected
+
+
+class Anime1MeExtractor:
+    """Extractor for anime1.me pages that require the Anime1 API."""
 
     def __init__(self, client: EpisodeSource) -> None:
         self.client = client
 
     def season_episode_urls(self, url: str) -> list[str]:
-        """Collect all episode URLs from a paginated season/category URL."""
+        """Collect all anime1.me episode URLs from a category URL."""
 
-        collected: list[str] = []
-        current_url: str | None = url
-        visited: set[str] = set()
-
-        while current_url:
-            if current_url in visited:
-                raise ParseError(f"season pagination loop detected: {current_url}")
-            visited.add(current_url)
-
-            page = parse_season_page(self.client.post_page(current_url))
-            collected.extend(urljoin(current_url, item) for item in page.episode_urls)
-            # Resolve relative pagination URLs against the page that produced them.
-            current_url = urljoin(current_url, page.next_url) if page.next_url else None
-
-        return collected
+        return collect_paginated_episode_urls(self.client.post_page, url)
 
     def episode(self, url: str) -> Episode:
-        """Resolve an episode page URL into stream URL, title, and cookies."""
+        """Resolve one anime1.me episode via page data-apireq and API response."""
 
         data_apireq, title = parse_episode_page(self.client.post_page(url))
         response = self.client.post_api(data_apireq)
@@ -204,3 +293,54 @@ class Anime1Extractor:
             stream_url=stream_url,
             cookies=extract_access_cookies(response),
         )
+
+
+class Anime1PwExtractor:
+    """Extractor for anime1.pw pages that expose direct MP4 sources."""
+
+    def __init__(self, client: EpisodeSource) -> None:
+        self.client = client
+
+    def season_episode_urls(self, url: str) -> list[str]:
+        """Collect all anime1.pw episode URLs from a category URL."""
+
+        return collect_paginated_episode_urls(self.client.get_page, url)
+
+    def episode(self, url: str) -> Episode:
+        """Resolve one anime1.pw episode directly from the page source tag."""
+
+        stream_url, title = parse_direct_episode_page(self.client.get_page(url), url)
+        return Episode(
+            page_url=url,
+            title=title,
+            stream_url=stream_url,
+            cookies={},
+        )
+
+
+class Anime1Extractor:
+    """Route supported Anime1 URLs to provider-specific extractors."""
+
+    def __init__(self, client: EpisodeSource) -> None:
+        self.extractors: dict[SourceKind, EpisodeExtractor] = {
+            ANIME1_ME_SOURCE: Anime1MeExtractor(client),
+            ANIME1_PW_SOURCE: Anime1PwExtractor(client),
+        }
+
+    def season_episode_urls(self, url: str) -> list[str]:
+        """Collect all episode URLs from a supported category URL."""
+
+        return self._extractor_for_url(url).season_episode_urls(url)
+
+    def episode(self, url: str) -> Episode:
+        """Resolve one supported episode URL into stream URL, title, and cookies."""
+
+        return self._extractor_for_url(url).episode(url)
+
+    def _extractor_for_url(self, url: str) -> EpisodeExtractor:
+        """Return the extractor that owns the URL's supported source kind."""
+
+        kind = source_kind(url)
+        if kind is None:
+            raise ParseError(f"unsupported Anime1 URL: {url}")
+        return self.extractors[kind]

--- a/src/anicat/urls.py
+++ b/src/anicat/urls.py
@@ -2,15 +2,33 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Sequence
+from typing import Final, Literal
+from urllib.parse import parse_qs, unquote, urlparse
 
 from .errors import AniCatError
 
-SEASON_URL_PATTERN = re.compile(r"^https?://(?:www\.)?anime1\.me/category/[^\s]+$", re.I)
-EPISODE_URL_PATTERN = re.compile(
-    r"^https?://(?:www\.)?anime1\.me/\d+/?(?:[?#][^\s]*)?$",
-    re.I,
-)
+SourceKind = Literal["anime1_me", "anime1_pw"]
+ANIME1_ME_SOURCE: Final[SourceKind] = "anime1_me"
+ANIME1_PW_SOURCE: Final[SourceKind] = "anime1_pw"
+ANIME1_ME_HOST = "anime1.me"
+ANIME1_PW_HOST = "anime1.pw"
+EPISODE_PATH_PATTERN = re.compile(r"^/\d+/?$")
 URL_SEPARATOR_PATTERN = re.compile(r"[,\s]+")
+SUPPORTED_SCHEMES = frozenset({"http", "https"})
+WORDPRESS_RESERVED_SLUGS = frozenset(
+    {
+        "about",
+        "contact",
+        "feed",
+        "page",
+        "privacy-policy",
+        "wp-admin",
+        "wp-content",
+        "wp-includes",
+        "wp-json",
+        "wp-login",
+    }
+)
 
 
 def split_urls(values: Sequence[str]) -> list[str]:
@@ -22,13 +40,70 @@ def split_urls(values: Sequence[str]) -> list[str]:
 def is_season_url(url: str) -> bool:
     """Return whether a URL points to an Anime1 category/season page."""
 
-    return bool(SEASON_URL_PATTERN.search(url))
+    parsed = urlparse(url)
+    kind = source_kind(url)
+    if kind == ANIME1_ME_SOURCE:
+        return parsed.path.startswith("/category/") and len(parsed.path) > len("/category/")
+    if kind == ANIME1_PW_SOURCE:
+        if is_numeric_episode_path(parsed.path):
+            return False
+        return has_numeric_category_query(parsed.query) or is_category_slug_path(parsed.path)
+    return False
 
 
 def is_episode_url(url: str) -> bool:
     """Return whether a URL points to an Anime1 episode page."""
 
-    return bool(EPISODE_URL_PATTERN.search(url))
+    return source_kind(url) is not None and is_numeric_episode_path(urlparse(url).path)
+
+
+def has_numeric_category_query(query: str) -> bool:
+    """Return whether a query string contains a numeric WordPress category ID."""
+
+    return any(value.isdigit() for value in parse_qs(query).get("cat", []))
+
+
+def is_numeric_episode_path(path: str) -> bool:
+    """Return whether a URL path matches Anime1's numeric episode permalink shape."""
+
+    return bool(EPISODE_PATH_PATTERN.fullmatch(path))
+
+
+def is_category_slug_path(path: str) -> bool:
+    """Return whether a path can be an anime1.pw category slug."""
+
+    slug = path.strip("/")
+    if not slug or "/" in slug or "." in slug:
+        return False
+
+    decoded_slug = unquote(slug)
+    normalized_slug = decoded_slug.lower()
+    if "/" in decoded_slug or normalized_slug.startswith("wp-"):
+        return False
+    if normalized_slug in WORDPRESS_RESERVED_SLUGS:
+        return False
+    return True
+
+
+def source_kind(url: str) -> SourceKind | None:
+    """Return the supported Anime1 source kind for a URL."""
+
+    if any(character.isspace() for character in url):
+        return None
+
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in SUPPORTED_SCHEMES:
+        return None
+
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+
+    if host == ANIME1_ME_HOST:
+        return ANIME1_ME_SOURCE
+    if host == ANIME1_PW_HOST:
+        return ANIME1_PW_SOURCE
+    return None
 
 
 def ensure_supported_url(url: str) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,16 @@ class ClientTests(unittest.TestCase):
             "application/x-www-form-urlencoded",
         )
 
+    def test_get_page_uses_get_method(self):
+        session = FakeSession()
+        client = Anime1Client(session=cast(Any, session))
+
+        client.get_page("https://anime1.pw/349")
+
+        method, url, _ = session.calls[0]
+        self.assertEqual(method, "GET")
+        self.assertEqual(url, "https://anime1.pw/349")
+
     def test_stream_video_uses_client_timeout(self):
         session = FakeSession()
         client = Anime1Client(session=cast(Any, session), timeout=(1.0, 2.0))

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import NoReturn
 from unittest.mock import patch
 
 import requests
@@ -6,13 +7,33 @@ from bs4 import BeautifulSoup, FeatureNotFound
 
 from anicat.errors import ParseError
 from anicat.extractor import (
+    Anime1Extractor,
     extract_access_cookies,
+    parse_direct_episode_page,
     parse_episode_page,
     parse_html,
     parse_season_page,
     parse_set_cookie_header,
     parse_stream_url,
 )
+
+
+class DirectPageClient:
+    def __init__(self, pages: dict[str, str]) -> None:
+        self.pages = pages
+        self.get_calls: list[str] = []
+        self.post_calls: list[str] = []
+
+    def get_page(self, url: str) -> str:
+        self.get_calls.append(url)
+        return self.pages[url]
+
+    def post_page(self, url: str) -> str:
+        self.post_calls.append(url)
+        return self.pages[url]
+
+    def post_api(self, data_apireq: str) -> NoReturn:
+        raise AssertionError("anime1.pw extraction should not call post_api")
 
 
 class ExtractorTests(unittest.TestCase):
@@ -38,6 +59,97 @@ class ExtractorTests(unittest.TestCase):
 
         self.assertEqual(data_apireq, "abc123")
         self.assertEqual(title, "Demo Episode")
+
+    def test_parse_direct_episode_page_extracts_title_and_source(self):
+        stream_url, title = parse_direct_episode_page(
+            """
+            <h1 class="entry-title"> Direct Demo [06] </h1>
+            <video class="video-js">
+                <source src="//pwvideo.example/60/6.mp4?h=token&e=1" type="video/mp4">
+            </video>
+            """,
+            "https://anime1.pw/349",
+        )
+
+        self.assertEqual(stream_url, "https://pwvideo.example/60/6.mp4?h=token&e=1")
+        self.assertEqual(title, "Direct Demo [06]")
+
+    def test_parse_direct_episode_page_prefers_mp4_source_and_warns(self):
+        with self.assertLogs("anicat.extractor", level="WARNING") as logs:
+            stream_url, title = parse_direct_episode_page(
+                """
+                <h1 class="entry-title"> Direct Demo [06] </h1>
+                <video class="video-js">
+                    <source src="//pwvideo.example/60/6.m3u8" type="application/x-mpegURL">
+                    <source src="//pwvideo.example/60/6.mp4?h=token&e=1" type="video/mp4">
+                </video>
+                """,
+                "https://anime1.pw/349",
+            )
+
+        self.assertEqual(stream_url, "https://pwvideo.example/60/6.mp4?h=token&e=1")
+        self.assertEqual(title, "Direct Demo [06]")
+        self.assertIn("2 source candidates", logs.output[0])
+        self.assertIn("1 MP4-compatible", logs.output[0])
+
+    def test_parse_direct_episode_page_accepts_untyped_mp4_source(self):
+        stream_url, title = parse_direct_episode_page(
+            """
+            <h1 class="entry-title"> Direct Demo [06] </h1>
+            <video class="video-js">
+                <source src="//pwvideo.example/60/6.mp4?h=token&e=1">
+            </video>
+            """,
+            "https://anime1.pw/349",
+        )
+
+        self.assertEqual(stream_url, "https://pwvideo.example/60/6.mp4?h=token&e=1")
+        self.assertEqual(title, "Direct Demo [06]")
+
+    def test_parse_direct_episode_page_rejects_missing_source(self):
+        with self.assertRaisesRegex(ParseError, "video source"):
+            parse_direct_episode_page('<h1 class="entry-title">Demo</h1>', "https://anime1.pw/1")
+
+    def test_parse_direct_episode_page_rejects_non_mp4_source(self):
+        with self.assertRaisesRegex(ParseError, "MP4 video source"):
+            parse_direct_episode_page(
+                """
+                <h1 class="entry-title">Direct Demo</h1>
+                <video class="video-js">
+                    <source src="//pwvideo.example/playlist.m3u8" type="application/x-mpegURL">
+                </video>
+                """,
+                "https://anime1.pw/1",
+            )
+
+    def test_parse_direct_episode_page_rejects_untyped_non_mp4_source(self):
+        with self.assertRaisesRegex(ParseError, "MP4 video source"):
+            parse_direct_episode_page(
+                """
+                <h1 class="entry-title">Direct Demo</h1>
+                <video class="video-js">
+                    <source src="//pwvideo.example/playlist.m3u8">
+                </video>
+                """,
+                "https://anime1.pw/1",
+            )
+
+    def test_parse_direct_episode_page_warns_when_no_source_is_mp4(self):
+        with self.assertLogs("anicat.extractor", level="WARNING") as logs:
+            with self.assertRaisesRegex(ParseError, "MP4 video source"):
+                parse_direct_episode_page(
+                    """
+                    <h1 class="entry-title">Direct Demo</h1>
+                    <video class="video-js">
+                        <source src="//pwvideo.example/playlist.m3u8">
+                        <source src="//pwvideo.example/video.webm" type="video/webm">
+                    </video>
+                    """,
+                    "https://anime1.pw/1",
+                )
+
+        self.assertIn("2 source candidates", logs.output[0])
+        self.assertIn("0 MP4-compatible", logs.output[0])
 
     def test_parse_html_falls_back_when_lxml_is_unavailable(self):
         parsers: list[str] = []
@@ -147,6 +259,59 @@ class ExtractorTests(unittest.TestCase):
 
         with self.assertRaises(ParseError):
             extract_access_cookies(response)
+
+    def test_anime1_pw_episode_uses_direct_source_without_api(self):
+        client = DirectPageClient(
+            {
+                "https://anime1.pw/349": """
+                <h1 class="entry-title">Direct Demo [06]</h1>
+                <video class="video-js">
+                    <source src="//pwvideo.example/60/6.mp4?h=token&e=1" type="video/mp4">
+                </video>
+                """,
+            }
+        )
+
+        episode = Anime1Extractor(client).episode("https://anime1.pw/349")
+
+        self.assertEqual(episode.page_url, "https://anime1.pw/349")
+        self.assertEqual(episode.title, "Direct Demo [06]")
+        self.assertEqual(episode.stream_url, "https://pwvideo.example/60/6.mp4?h=token&e=1")
+        self.assertEqual(episode.cookies, {})
+        self.assertEqual(client.get_calls, ["https://anime1.pw/349"])
+        self.assertEqual(client.post_calls, [])
+
+    def test_anime1_pw_category_collects_episode_urls(self):
+        client = DirectPageClient(
+            {
+                "https://anime1.pw/?cat=60": """
+                <h2 class="entry-title">
+                    <a href="https://anime1.pw/349" rel="bookmark">Episode 6</a>
+                </h2>
+                <h2 class="entry-title">
+                    <a href="/348" rel="bookmark">Episode 5</a>
+                </h2>
+                """,
+            }
+        )
+
+        urls = Anime1Extractor(client).season_episode_urls("https://anime1.pw/?cat=60")
+
+        self.assertEqual(urls, ["https://anime1.pw/349", "https://anime1.pw/348"])
+        self.assertEqual(client.get_calls, ["https://anime1.pw/?cat=60"])
+        self.assertEqual(client.post_calls, [])
+
+    def test_anime1_pw_category_rejects_empty_episode_list(self):
+        client = DirectPageClient(
+            {
+                "https://anime1.pw/?cat=60": """
+                <html><body><p>No matching selector anymore.</p></body></html>
+                """,
+            }
+        )
+
+        with self.assertRaisesRegex(ParseError, "no episode links"):
+            Anime1Extractor(client).season_episode_urls("https://anime1.pw/?cat=60")
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_smoke.py
+++ b/tests/test_integration_smoke.py
@@ -5,7 +5,9 @@ from anicat.client import Anime1Client
 from anicat.extractor import Anime1Extractor
 
 RUN_INTEGRATION = os.environ.get("ANICAT_RUN_INTEGRATION") == "1"
+RUN_PW_INTEGRATION = os.environ.get("ANICAT_RUN_PW_INTEGRATION") == "1"
 SMOKE_URL = os.environ.get("ANICAT_SMOKE_URL", "https://anime1.me/28979")
+PW_SMOKE_URL = os.environ.get("ANICAT_PW_SMOKE_URL", "https://anime1.pw/349")
 
 
 @unittest.skipUnless(RUN_INTEGRATION, "set ANICAT_RUN_INTEGRATION=1 to run Anime1 smoke tests")
@@ -18,6 +20,36 @@ class Anime1SmokeTests(unittest.TestCase):
                 "GET",
                 episode.stream_url,
                 cookies=dict(episode.cookies),
+                headers={
+                    "Accept-Encoding": "identity",
+                    "Range": "bytes=0-1",
+                },
+                stream=True,
+            )
+            try:
+                body = next(response.iter_content(chunk_size=2), b"")
+
+                self.assertEqual(response.status_code, 206)
+                self.assertRegex(response.headers.get("Content-Range", ""), r"^bytes 0-1/\d+$")
+                self.assertEqual(len(body), 2)
+            finally:
+                response.close()
+        finally:
+            client.close()
+
+
+@unittest.skipUnless(
+    RUN_PW_INTEGRATION,
+    "set ANICAT_RUN_PW_INTEGRATION=1 to run Anime1.pw smoke tests",
+)
+class Anime1PwSmokeTests(unittest.TestCase):
+    def test_direct_video_source_supports_resume_contract(self):
+        client = Anime1Client(timeout=(10.0, 30.0), retries=1)
+        try:
+            episode = Anime1Extractor(client).episode(PW_SMOKE_URL)
+            response = client.request(
+                "GET",
+                episode.stream_url,
                 headers={
                     "Accept-Encoding": "identity",
                     "Range": "bytes=0-1",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12,6 +12,9 @@ from anicat.service import AniCatService
 
 
 class BadClient:
+    def get_page(self, url: str) -> str:
+        return "<html></html>"
+
     def post_page(self, url: str) -> str:
         return "<html></html>"
 
@@ -72,6 +75,9 @@ class GoodClient:
         <video class="video-js" data-apireq="%7B%7D"></video>
         """
 
+    def get_page(self, url: str) -> str:
+        return self.post_page(url)
+
     def post_api(self, data_apireq: str) -> requests.Response:
         return cast(requests.Response, ApiResponse())
 
@@ -82,6 +88,42 @@ class GoodClient:
         cookies: Mapping[str, str],
         headers: Mapping[str, str] | None = None,
     ) -> VideoStreamResponse:
+        return VideoResponse()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DirectClient:
+    instances: ClassVar[list["DirectClient"]] = []
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.stream_calls: list[tuple[str, dict[str, str]]] = []
+        self.instances.append(self)
+
+    def get_page(self, url: str) -> str:
+        return """
+        <h1 class="entry-title">Direct Demo</h1>
+        <video class="video-js">
+            <source src="//pwvideo.example/60/6.mp4?h=token&e=1" type="video/mp4">
+        </video>
+        """
+
+    def post_page(self, url: str) -> NoReturn:
+        raise AssertionError("anime1.pw extraction should use get_page")
+
+    def post_api(self, data_apireq: str) -> NoReturn:
+        raise AssertionError("direct source extraction should not call post_api")
+
+    def stream_video(
+        self,
+        url: str,
+        *,
+        cookies: Mapping[str, str],
+        headers: Mapping[str, str] | None = None,
+    ) -> VideoStreamResponse:
+        self.stream_calls.append((url, dict(cookies)))
         return VideoResponse()
 
     def close(self) -> None:
@@ -182,6 +224,26 @@ class ServiceTests(unittest.TestCase):
         self.assertEqual(urls, ["https://anime1.me/1"])
         self.assertEqual(len(GoodClient.instances), 1)
         self.assertTrue(GoodClient.instances[0].closed)
+
+    def test_download_one_supports_anime1_pw_direct_source(self):
+        DirectClient.instances.clear()
+
+        with TemporaryDirectory() as directory:
+            service = AniCatService(
+                DownloadOptions(output_dir=Path(directory), chunk_size=1024),
+                client_factory=DirectClient,
+            )
+
+            report = service.download_one("https://anime1.pw/349")
+
+            result = report.result
+            assert result is not None
+            self.assertEqual(result.path.read_bytes(), VideoResponse.content)
+            self.assertEqual(
+                DirectClient.instances[0].stream_calls,
+                [("https://pwvideo.example/60/6.mp4?h=token&e=1", {})],
+            )
+            self.assertTrue(DirectClient.instances[0].closed)
 
 
 if __name__ == "__main__":

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,7 +1,14 @@
 import unittest
 
 from anicat.errors import AniCatError
-from anicat.urls import dedupe, ensure_supported_url, is_episode_url, is_season_url, split_urls
+from anicat.urls import (
+    dedupe,
+    ensure_supported_url,
+    is_episode_url,
+    is_season_url,
+    source_kind,
+    split_urls,
+)
 
 
 class UrlTests(unittest.TestCase):
@@ -24,14 +31,50 @@ class UrlTests(unittest.TestCase):
     def test_classifies_supported_urls(self):
         self.assertTrue(is_episode_url("https://anime1.me/15651"))
         self.assertTrue(is_season_url("https://anime1.me/category/2021/example"))
+        self.assertTrue(is_episode_url("https://anime1.pw/349"))
+        self.assertTrue(is_season_url("https://anime1.pw/?cat=60"))
+        self.assertTrue(
+            is_season_url(
+                "https://anime1.pw/"
+                "%E6%A3%AE%E6%9E%97%E8%A3%A1%E7%9A%84%E7%86%8A%E5%85%88%E7%94%9F"
+                "%EF%BC%8C%E5%86%AC%E7%9C%A0%E4%B8%AD%E3%80%82?cat=27"
+            )
+        )
+        self.assertTrue(
+            is_season_url(
+                "https://anime1.pw/"
+                "%E6%A3%AE%E6%9E%97%E8%A3%A1%E7%9A%84%E7%86%8A%E5%85%88%E7%94%9F"
+                "%EF%BC%8C%E5%86%AC%E7%9C%A0%E4%B8%AD%E3%80%82"
+            )
+        )
+        self.assertTrue(is_season_url("https://anime1.pw/english-category"))
+        self.assertTrue(
+            is_season_url(
+                "https://anime1.pw/"
+                "%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA"
+            )
+        )
+        self.assertEqual(source_kind("https://anime1.me/15651"), "anime1_me")
+        self.assertEqual(source_kind("https://anime1.pw/349"), "anime1_pw")
 
     def test_rejects_unsupported_urls(self):
         with self.assertRaises(AniCatError):
             ensure_supported_url("https://example.com/15651")
+        self.assertFalse(is_episode_url("https://anime1.cc/681899930-01-0142"))
+        self.assertFalse(is_episode_url("https://anime1.in/2023-xian-ni-10142000"))
+        self.assertFalse(is_season_url("https://anime1.pw/"))
+        self.assertFalse(is_season_url("https://anime1.pw/349?cat=60"))
+        self.assertFalse(is_season_url("https://anime1.pw/wp-login.php"))
+        self.assertFalse(is_season_url("https://anime1.pw/wp-content/uploads/foo.jpg"))
+        self.assertFalse(is_season_url("https://anime1.pw/feed/"))
+        self.assertFalse(is_season_url("https://anime1.pw/page/2/"))
+        self.assertFalse(is_season_url("https://anime1.pw/about"))
+        self.assertFalse(is_season_url("https://anime1.pw/category%2Fsmuggled"))
 
     def test_rejects_episode_url_with_trailing_garbage(self):
         self.assertFalse(is_episode_url("https://anime1.me/15651abc"))
         self.assertFalse(is_episode_url("https://anime1.me/15651/extra"))
+        self.assertFalse(is_episode_url("https://anime1.pw/349/extra"))
 
     def test_dedupe_keeps_order(self):
         self.assertEqual(dedupe(["a", "b", "a", "c"]), ["a", "b", "c"])


### PR DESCRIPTION
## 摘要

新增 `anime1.pw` 支援，讓 AniCat 可以下載 `.pw` 單集、`?cat=` 分類頁與 slug 分類頁。

此 PR 同時把 Anime1 來源解析拆成 provider-specific extractor，避免把 `.me` 與 `.pw` 的請求模型硬塞在同一套流程裡。

## 主要變更

### anime1.pw 支援

- 支援 `https://anime1.pw/<episode-id>` 單集頁
- 支援 `https://anime1.pw/?cat=<id>` 分類頁
- 支援 `https://anime1.pw/<slug>` 分類頁，包含中文、英文、日文 slug
- `.pw` 頁面改用 `GET` 抓 HTML，直接解析 `<video>/<source>` MP4 來源
- `.me` 仍保留原本 `POST` 頁面與 API 流程

### Extractor 架構調整

- 新增 provider-specific extractor：
  - `Anime1MeExtractor`
  - `Anime1PwExtractor`
- 由 `source_kind()` 判斷來源後分派到對應 extractor
- 共用分類頁 episode link 收集邏輯，避免 `.me` / `.pw` 重複 parser
- direct video parser 只接受 MP4-compatible source，避免把未支援的 HLS / m3u8 塞進現有 MP4 downloader

### URL 判斷強化

- 新增 `anime1.pw` URL classification
- 支援 `.pw` numeric episode、`?cat=`、slug category
- 避免接受 WordPress/system path、multi-segment path、encoded slash 等不明 URL

### 文件與流程

- README 更新支援來源與使用方式
- CHANGELOG 加入 unreleased 條目
- 新增 CONTRIBUTING.md，整理專案結構、開發規範、測試策略與 release 流程

## 行為差異

- `anime1.me`：維持既有 POST/API 解析流程
- `anime1.pw`：使用 GET 頁面解析 direct MP4 source
- `anime1.cc` / `anime1.in`：仍未支援，因為目前觀察偏向 HLS / m3u8，需另做 HLS backend

## Test plan

- [x] `poetry run ruff format --check .`
- [x] `poetry run ruff check .`
- [x] `poetry run pyright`
- [x] `poetry run python -m unittest`
- [x] `poetry check`
- [x] `poetry run pre-commit run --all-files`
- [x] `poetry build`
- [x] `ANICAT_RUN_PW_INTEGRATION=1 poetry run python -m unittest tests.test_integration_smoke`

## Release note

- Added support for `anime1.pw` direct MP4 episode and category pages.