### PR TITLE
feat(cli): add search subcommand for the Anime1 catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- 省略必要參數時的互動提問邏輯抽成共用 helper，`anicat` 與 `anicat search` 行為一致：TTY 下提問，非互動環境直接回報 usage error 而非卡住。
 - `anime1.pw` 頁面解析改用 GET 抓取 HTML，避免依賴 WordPress / Cloudflare 對 POST 頁面請求的相容行為。
 - direct video parser 會優先選擇 `video/mp4` source；若頁面提供多個 source 會記錄 warning。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- 新增 `anicat search KEYWORD` 子指令：查詢 Anime1 目錄索引並印出可直接下載的分類 URL，不必自行到網站複製網址。
+- 新增 `anicat.catalog` 模組（`fetch_catalog` / `search_catalog` / `parse_catalog`）與 `AnimeEntry` model，並由 root package re-export `AnimeEntry`。
 - 支援 `anime1.pw` 單集、`?cat=` 分類頁與 slug 分類頁下載；此來源直接解析頁面 MP4 source，沿用現有 Range 續傳下載流程。
 
 ### Changed
@@ -13,6 +15,7 @@
 
 ### Fixed
 
+- `anime1.me` 的 `?cat=N` 分類 URL 先前被判定為不支援，但那正是 Anime1 目錄索引使用的連結形式；現已與 `anime1.pw` 的判斷邏輯一致。
 - 分類頁 HTML 無法解析出 episode link 時改為回報 `ParseError`，避免 selector 失效時 silent 回傳 0 集。
 
 ## 0.1.0 - 2026-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- 新增 `anicat search KEYWORD` 子指令：查詢 Anime1 目錄索引並印出可直接下載的分類 URL，不必自行到網站複製網址。
+- 新增 `anicat search KEYWORD` 子指令：查詢 Anime1 目錄索引並印出可直接下載的分類 URL，不必自行到網站複製網址；結果以 Rich table 呈現，URL 欄位固定寬度確保任何終端寬度都不會被裁切。
 - 新增 `anicat.catalog` 模組（`fetch_catalog` / `search_catalog` / `parse_catalog`）與 `AnimeEntry` model，並由 root package re-export `AnimeEntry`。
 - 支援 `anime1.pw` 單集、`?cat=` 分類頁與 slug 分類頁下載；此來源直接解析頁面 MP4 source，沿用現有 Range 續傳下載流程。
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,26 @@ anicat --help
 
 ```bash
 anicat URL [URL ...] [OPTIONS]
+anicat search KEYWORD
 ```
 
 ### 範例
+
+0. 先搜尋再下載（不必自己去網站找 URL）：
+
+    ```bash
+    anicat search 碧藍之海
+    ```
+
+    ```text
+    GRAND BLUE 碧藍之海 第三季 [連載中(07) · 2026 夏]
+      -> https://anime1.me/?cat=1935
+    GRAND BLUE 碧藍之海 第二季 [1-12 · 2025 夏 · 悠哈璃羽]
+      -> https://anime1.me/?cat=1708
+    + 2 result(s)
+    ```
+
+    把印出的網址直接餵回 `anicat` 即可下載整季。
 
 1. 單集下載：
 
@@ -75,6 +92,7 @@ anicat URL [URL ...] [OPTIONS]
 
     ```bash
     anicat https://anime1.me/category/your-category-slug
+    anicat https://anime1.me/?cat=1935
     anicat https://anime1.pw/your-category-slug
     ```
 
@@ -105,7 +123,18 @@ anicat URL [URL ...] [OPTIONS]
 完整參數：
 ```bash
 anicat --help
+anicat search --help
 ```
+
+### `anicat search`
+
+| 參數 | 說明 |
+|---|---|
+| `KEYWORD` | 比對動畫標題的子字串，不分大小寫 |
+| `-v`, `--verbose` | 顯示診斷 log |
+| `-q`, `--quiet` | 只保留錯誤等級 log |
+
+搜尋來源是 Anime1 的目錄索引 `animelist.json`，即時抓取不做快取。找不到相符項目時 exit code 為 `1`。
 
 ## 進階說明
 
@@ -125,12 +154,25 @@ episode_urls = service.collect_episode_urls(["https://anime1.me/15651"])
 reports = service.download_many(episode_urls)
 ```
 
+搜尋目錄索引：
+
+```python
+from anicat import Anime1Client
+from anicat.catalog import fetch_catalog, search_catalog
+
+with Anime1Client() as client:
+    matches = search_catalog(fetch_catalog(client), "碧藍之海")
+
+for entry in matches:
+    print(entry.title, entry.url)
+```
+
 ### Exit Codes
 
 | Code | 意義 |
 |---|---|
 | `0` | 全部下載成功，或目標檔案已存在而略過 |
-| `1` | 至少一個 URL 失敗，或沒有找到任何集數 |
+| `1` | 至少一個 URL 失敗、沒有找到任何集數，或搜尋沒有相符項目 |
 | `2` | CLI 使用方式或參數錯誤，例如沒有輸入 URL |
 
 ## 貢獻

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ anicat search KEYWORD
     ```
 
     ```text
-    GRAND BLUE 碧藍之海 第三季 [連載中(07) · 2026 夏]
-      -> https://anime1.me/?cat=1935
-    GRAND BLUE 碧藍之海 第二季 [1-12 · 2025 夏 · 悠哈璃羽]
-      -> https://anime1.me/?cat=1708
-    + 2 result(s)
+     Title                        Episodes · Season                   URL
+     ─────────────────────────────────────────────────────────────────────────────────────
+     GRAND BLUE 碧藍之海 第三季   連載中(07) · 2026 夏                https://anime1.me/?cat=1935
+     GRAND BLUE 碧藍之海 第二季   1-12 · 2025 夏 · 悠哈璃羽           https://anime1.me/?cat=1708
+     碧藍之海                     1-12 · 2018 夏 · 悠哈璃羽&西農YUI   https://anime1.me/?cat=388
+
+    + 3 result(s)
     ```
+
+    URL 欄位固定寬度，終端機再窄也不會被裁切，可以直接複製貼上。
 
     把印出的網址直接餵回 `anicat` 即可下載整季。
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ anicat search --help
 
 搜尋來源是 Anime1 的目錄索引 `animelist.json`，即時抓取不做快取。找不到相符項目時 exit code 為 `1`。
 
+省略 `KEYWORD` 時會互動提問（與 `anicat` 省略 URL 時的行為一致）：
+
+```text
+$ anicat search
+? Search keyword：碧藍之海
+```
+
+在管線或 CI 等非互動環境下不會卡住，直接以 exit code `2` 回報。
+
 ## 進階說明
 
 ### Python API

--- a/src/anicat/__init__.py
+++ b/src/anicat/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from .client import Anime1Client
 from .errors import AniCatError, DownloadError, FetchError, ParseError
-from .models import DownloadProgressEvent, DownloadResult, Episode, JobReport
+from .models import AnimeEntry, DownloadProgressEvent, DownloadResult, Episode, JobReport
 from .options import DownloadOptions
 from .service import AniCatService
 
@@ -12,6 +12,7 @@ __all__ = [
     "AniCatError",
     "AniCatService",
     "Anime1Client",
+    "AnimeEntry",
     "DownloadError",
     "DownloadOptions",
     "DownloadProgressEvent",

--- a/src/anicat/catalog.py
+++ b/src/anicat/catalog.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+from .constants import ANIME_LIST_URL
+from .errors import ParseError
+from .extractor import parse_html
+from .models import AnimeEntry
+from .urls import ANIME1_ME_HOST
+
+CATALOG_COLUMN_COUNT = 6
+LOGGER = logging.getLogger(__name__)
+
+
+class CatalogSource(Protocol):
+    """Minimal HTTP dependency required to read the Anime1 catalogue."""
+
+    def get_page(self, url: str) -> str:
+        """Return the raw body of an Anime1 URL fetched with GET."""
+
+        ...
+
+
+def fetch_catalog(client: CatalogSource) -> list[AnimeEntry]:
+    """Fetch and parse the full Anime1 catalogue index."""
+
+    entries = parse_catalog(client.get_page(ANIME_LIST_URL))
+    LOGGER.info("Loaded %d catalogue entries", len(entries))
+    return entries
+
+
+def parse_catalog(payload: str) -> list[AnimeEntry]:
+    """Parse an animelist.json payload into catalogue entries."""
+
+    try:
+        rows = json.loads(payload)
+    except ValueError as error:
+        raise ParseError("catalogue response is not JSON") from error
+
+    if not isinstance(rows, list):
+        raise ParseError(f"catalogue payload is {type(rows).__name__}, expected a list")
+
+    entries = [entry for row in rows if (entry := parse_entry(row)) is not None]
+    if rows and not entries:
+        raise ParseError("catalogue payload contained no usable rows")
+    return entries
+
+
+def parse_entry(row: Any) -> AnimeEntry | None:
+    """Convert one catalogue row, or return None when its shape is unusable."""
+
+    if not isinstance(row, list) or len(row) < CATALOG_COLUMN_COUNT:
+        LOGGER.warning("Skipping malformed catalogue row: %r", row)
+        return None
+
+    anime_id, title, episodes, year, season, subtitle_group = row[:CATALOG_COLUMN_COUNT]
+    if not isinstance(anime_id, int):
+        LOGGER.warning("Skipping catalogue row with a non-numeric ID: %r", row)
+        return None
+
+    if anime_id:
+        return AnimeEntry(
+            anime_id=anime_id,
+            title=str(title),
+            episodes=str(episodes),
+            year=str(year),
+            season=str(season),
+            subtitle_group=str(subtitle_group),
+            url=f"https://{ANIME1_ME_HOST}/?cat={anime_id}",
+        )
+
+    # Anime1 marks anime1.pw entries with ID 0 and stores an anchor tag in the
+    # title column instead of a plain title, so the real URL lives in the markup.
+    anchor = parse_html(str(title)).a
+    href = anchor.get("href") if anchor is not None else None
+    if anchor is None or not isinstance(href, str):
+        LOGGER.warning("Skipping anime1.pw row without a usable link: %r", row)
+        return None
+
+    return AnimeEntry(
+        anime_id=anime_id,
+        title=anchor.get_text(strip=True),
+        episodes=str(episodes),
+        year=str(year),
+        season=str(season),
+        subtitle_group=str(subtitle_group),
+        url=href.strip(),
+    )
+
+
+def search_catalog(entries: Iterable[AnimeEntry], keyword: str) -> list[AnimeEntry]:
+    """Return catalogue entries whose title contains keyword, ignoring case."""
+
+    needle = keyword.casefold()
+    return [entry for entry in entries if needle in entry.title.casefold()]

--- a/src/anicat/cli.py
+++ b/src/anicat/cli.py
@@ -6,6 +6,10 @@ import time
 from collections.abc import Sequence
 from pathlib import Path
 
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
 from . import __version__
 from .catalog import fetch_catalog, search_catalog
 from .client import Anime1Client
@@ -247,19 +251,38 @@ def search_main(argv: Sequence[str]) -> int:
         print(f"- No catalogue match for {args.keyword!r}.", file=sys.stderr)
         return EXIT_FAILURE
 
-    for entry in entries:
-        print(format_entry(entry))
-        print(f"  -> {entry.url}")
-    print(f"+ {len(entries)} result(s)")
+    render_search_results(entries)
     return EXIT_OK
 
 
-def format_entry(entry: AnimeEntry) -> str:
-    """Render one catalogue entry as a single summary line."""
+def render_search_results(entries: Sequence[AnimeEntry]) -> None:
+    """Render catalogue matches, keeping the URL column intact for copy/paste."""
+
+    # The URL is the payload of this command, so pin its column to the widest
+    # value. Narrow terminals then shrink the title and metadata instead of
+    # cropping a URL into something that cannot be pasted back.
+    table = Table(box=box.SIMPLE_HEAD, header_style="bold cyan", pad_edge=False)
+    table.add_column("Title", style="bold", overflow="fold")
+    table.add_column("Episodes · Season", style="dim")
+    table.add_column(
+        "URL",
+        style="cyan",
+        no_wrap=True,
+        width=max(len(entry.url) for entry in entries),
+    )
+    for entry in entries:
+        table.add_row(entry.title, format_entry_meta(entry), entry.url)
+
+    console = Console()
+    console.print(table)
+    console.print(f"[green]+[/green] {len(entries)} result(s)")
+
+
+def format_entry_meta(entry: AnimeEntry) -> str:
+    """Join the episode, season and subtitle-group metadata of one entry."""
 
     parts = (entry.episodes, f"{entry.year} {entry.season}".strip(), entry.subtitle_group)
-    details = " · ".join(part for part in parts if part)
-    return f"{entry.title} [{details}]"
+    return " · ".join(part for part in parts if part)
 
 
 def options_from_args(args: argparse.Namespace) -> DownloadOptions:

--- a/src/anicat/cli.py
+++ b/src/anicat/cli.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from . import __version__
+from .catalog import fetch_catalog, search_catalog
+from .client import Anime1Client
 from .constants import (
     DEFAULT_CHUNK_SIZE,
     DEFAULT_CONCURRENCY,
@@ -17,7 +19,7 @@ from .constants import (
 )
 from .errors import AniCatError
 from .logging_config import configure_logging
-from .models import JobReport
+from .models import AnimeEntry, JobReport
 from .options import DownloadOptions
 from .progress import rich_download_progress
 from .service import AniCatService
@@ -26,6 +28,7 @@ from .urls import split_urls
 EXIT_OK = 0
 EXIT_FAILURE = 1
 EXIT_USAGE = 2
+SEARCH_COMMAND = "search"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,9 +39,12 @@ def build_parser() -> argparse.ArgumentParser:
         description="Download Anime1 episodes from episode or category URLs.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
+            "Commands:\n"
+            "  search <keyword>  List catalogue matches and their category URLs\n"
+            "\n"
             "Exit codes:\n"
             "  0  All downloads completed or were skipped\n"
-            "  1  At least one URL failed or no episode was found\n"
+            "  1  At least one URL failed, no episode was found, or nothing matched\n"
             "  2  Invalid CLI usage or options"
         ),
     )
@@ -124,11 +130,45 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_search_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the catalogue search subcommand."""
+
+    parser = argparse.ArgumentParser(
+        prog="anicat search",
+        description="Search the Anime1 catalogue and print matching category URLs.",
+    )
+    parser.add_argument(
+        "keyword",
+        help="Substring matched against anime titles, ignoring case.",
+    )
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Show diagnostic logs. Use -vv for HTTP-level debug details.",
+    )
+    verbosity_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress diagnostic logs except errors.",
+    )
+    return parser
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the AniCat CLI and return a process exit code."""
 
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    # Dispatched before the download parser so that plain `anicat <url>` keeps
+    # working without requiring a subcommand.
+    if arguments and arguments[0] == SEARCH_COMMAND:
+        return search_main(arguments[1:])
+
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(arguments)
     configure_logging(verbose=args.verbose, quiet=args.quiet)
     try:
         options = options_from_args(args)
@@ -185,6 +225,41 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{len(downloaded)} downloaded, {len(skipped)} skipped, {len(failed)} failed"
     )
     return EXIT_FAILURE if failed else EXIT_OK
+
+
+def search_main(argv: Sequence[str]) -> int:
+    """Run the catalogue search subcommand and return a process exit code."""
+
+    parser = build_search_parser()
+    args = parser.parse_args(argv)
+    configure_logging(verbose=args.verbose, quiet=args.quiet)
+
+    client = Anime1Client()
+    try:
+        entries = search_catalog(fetch_catalog(client), args.keyword)
+    except AniCatError as error:
+        print(f"- {error}", file=sys.stderr)
+        return EXIT_FAILURE
+    finally:
+        client.close()
+
+    if not entries:
+        print(f"- No catalogue match for {args.keyword!r}.", file=sys.stderr)
+        return EXIT_FAILURE
+
+    for entry in entries:
+        print(format_entry(entry))
+        print(f"  -> {entry.url}")
+    print(f"+ {len(entries)} result(s)")
+    return EXIT_OK
+
+
+def format_entry(entry: AnimeEntry) -> str:
+    """Render one catalogue entry as a single summary line."""
+
+    parts = (entry.episodes, f"{entry.year} {entry.season}".strip(), entry.subtitle_group)
+    details = " · ".join(part for part in parts if part)
+    return f"{entry.title} [{details}]"
 
 
 def options_from_args(args: argparse.Namespace) -> DownloadOptions:

--- a/src/anicat/cli.py
+++ b/src/anicat/cli.py
@@ -143,6 +143,7 @@ def build_search_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "keyword",
+        nargs="?",
         help="Substring matched against anime titles, ignoring case.",
     )
     verbosity_group = parser.add_mutually_exclusive_group()
@@ -180,16 +181,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"argument error: {error}", file=sys.stderr)
         return EXIT_USAGE
 
-    input_urls = split_urls(args.urls)
-    if not input_urls:
-        if not sys.stdin.isatty():
-            print("No URL provided.", file=sys.stderr)
-            return EXIT_USAGE
-        try:
-            input_urls = split_urls([input("? Anime1 URL：")])
-        except EOFError:
-            print("No URL provided.", file=sys.stderr)
-            return EXIT_USAGE
+    input_urls = split_urls(args.urls) or split_urls([prompt_for("? Anime1 URL：")])
     if not input_urls:
         print("No URL provided.", file=sys.stderr)
         return EXIT_USAGE
@@ -231,6 +223,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     return EXIT_FAILURE if failed else EXIT_OK
 
 
+def prompt_for(label: str) -> str:
+    """Ask for one missing argument, returning empty when input is unavailable."""
+
+    # Piped or redirected input must fail with usage instead of blocking.
+    if not sys.stdin.isatty():
+        return ""
+    try:
+        return input(label).strip()
+    except EOFError:
+        return ""
+
+
 def search_main(argv: Sequence[str]) -> int:
     """Run the catalogue search subcommand and return a process exit code."""
 
@@ -238,9 +242,14 @@ def search_main(argv: Sequence[str]) -> int:
     args = parser.parse_args(argv)
     configure_logging(verbose=args.verbose, quiet=args.quiet)
 
+    keyword = (args.keyword or "").strip() or prompt_for("? Search keyword：")
+    if not keyword:
+        print("No keyword provided.", file=sys.stderr)
+        return EXIT_USAGE
+
     client = Anime1Client()
     try:
-        entries = search_catalog(fetch_catalog(client), args.keyword)
+        entries = search_catalog(fetch_catalog(client), keyword)
     except AniCatError as error:
         print(f"- {error}", file=sys.stderr)
         return EXIT_FAILURE
@@ -248,7 +257,7 @@ def search_main(argv: Sequence[str]) -> int:
         client.close()
 
     if not entries:
-        print(f"- No catalogue match for {args.keyword!r}.", file=sys.stderr)
+        print(f"- No catalogue match for {keyword!r}.", file=sys.stderr)
         return EXIT_FAILURE
 
     render_search_results(entries)
@@ -273,7 +282,9 @@ def render_search_results(entries: Sequence[AnimeEntry]) -> None:
     for entry in entries:
         table.add_row(entry.title, format_entry_meta(entry), entry.url)
 
-    console = Console()
+    # Rich's automatic highlighter recolours numbers and stray words in the
+    # summary line, which fights the styling the table already applies.
+    console = Console(highlight=False)
     console.print(table)
     console.print(f"[green]+[/green] {len(entries)} result(s)")
 

--- a/src/anicat/constants.py
+++ b/src/anicat/constants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 API_URL = "https://v.anime1.me/api"
+ANIME_LIST_URL = "https://anime1.me/animelist.json"
 DEFAULT_OUTPUT_DIR_NAME = "Anime1_Download"
 
 DEFAULT_CONCURRENCY = 3

--- a/src/anicat/models.py
+++ b/src/anicat/models.py
@@ -33,6 +33,19 @@ class VideoStreamResponse(Protocol):
 
 
 @dataclass(frozen=True)
+class AnimeEntry:
+    """One anime series listed in the Anime1 catalogue index."""
+
+    anime_id: int
+    title: str
+    episodes: str
+    year: str
+    season: str
+    subtitle_group: str
+    url: str
+
+
+@dataclass(frozen=True)
 class Episode:
     """Resolved metadata required to download a single Anime1 episode."""
 

--- a/src/anicat/urls.py
+++ b/src/anicat/urls.py
@@ -43,6 +43,10 @@ def is_season_url(url: str) -> bool:
     parsed = urlparse(url)
     kind = source_kind(url)
     if kind == ANIME1_ME_SOURCE:
+        if is_numeric_episode_path(parsed.path):
+            return False
+        if has_numeric_category_query(parsed.query):
+            return True
         return parsed.path.startswith("/category/") and len(parsed.path) > len("/category/")
     if kind == ANIME1_PW_SOURCE:
         if is_numeric_episode_path(parsed.path):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,128 @@
+import json
+import unittest
+
+from anicat.catalog import fetch_catalog, parse_catalog, search_catalog
+from anicat.constants import ANIME_LIST_URL
+from anicat.errors import ParseError
+
+ME_ROW = [1935, "GRAND BLUE 碧藍之海 第三季", "連載中(07)", "2026", "夏", ""]
+PW_ROW = [
+    0,
+    '<a href="https://anime1.pw/?cat=62">關於相同研討會的染谷同學是性感女優這檔事。</a>',
+    "連載中(04)",
+    "2026",
+    "夏",
+    "桜都",
+]
+
+
+class FakeCatalogClient:
+    """Catalogue source that returns a canned payload without touching network."""
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+        self.requested: list[str] = []
+
+    def get_page(self, url: str) -> str:
+        self.requested.append(url)
+        return self.payload
+
+
+class ParseCatalogTests(unittest.TestCase):
+    def test_anime1_me_row_builds_category_url(self):
+        entry = parse_catalog(json.dumps([ME_ROW]))[0]
+
+        self.assertEqual(entry.anime_id, 1935)
+        self.assertEqual(entry.title, "GRAND BLUE 碧藍之海 第三季")
+        self.assertEqual(entry.episodes, "連載中(07)")
+        self.assertEqual(entry.year, "2026")
+        self.assertEqual(entry.season, "夏")
+        self.assertEqual(entry.subtitle_group, "")
+        self.assertEqual(entry.url, "https://anime1.me/?cat=1935")
+
+    def test_anime1_pw_row_unwraps_anchor_into_title_and_url(self):
+        entry = parse_catalog(json.dumps([PW_ROW]))[0]
+
+        self.assertEqual(entry.anime_id, 0)
+        self.assertEqual(entry.title, "關於相同研討會的染谷同學是性感女優這檔事。")
+        self.assertEqual(entry.url, "https://anime1.pw/?cat=62")
+        self.assertEqual(entry.subtitle_group, "桜都")
+
+    def test_duplicate_titles_are_both_kept(self):
+        rows = [
+            [1608, "灰色：幻影扳機", "1-13", "2025", "冬", "桜都"],
+            [539, "灰色：幻影扳機", "1-3", "2019", "冬", "喵萌奶茶屋"],
+        ]
+
+        entries = parse_catalog(json.dumps(rows))
+
+        self.assertEqual([entry.anime_id for entry in entries], [1608, 539])
+
+    def test_malformed_rows_are_skipped_without_losing_valid_rows(self):
+        rows = [ME_ROW, "not-a-row", [1, "too", "short"], [None, "bad id", "", "", "", ""]]
+
+        with self.assertLogs("anicat.catalog", level="WARNING"):
+            entries = parse_catalog(json.dumps(rows))
+
+        self.assertEqual([entry.anime_id for entry in entries], [1935])
+
+    def test_anime1_pw_row_without_anchor_is_skipped(self):
+        rows = [ME_ROW, [0, "plain title, no anchor", "1-8", "2024", "夏", "桜都"]]
+
+        with self.assertLogs("anicat.catalog", level="WARNING"):
+            entries = parse_catalog(json.dumps(rows))
+
+        self.assertEqual([entry.anime_id for entry in entries], [1935])
+
+    def test_empty_catalogue_is_allowed(self):
+        self.assertEqual(parse_catalog("[]"), [])
+
+    def test_payload_with_only_unusable_rows_raises_parse_error(self):
+        with self.assertLogs("anicat.catalog", level="WARNING"), self.assertRaises(ParseError):
+            parse_catalog(json.dumps(["nope", "still nope"]))
+
+    def test_non_json_payload_raises_parse_error(self):
+        with self.assertRaises(ParseError):
+            parse_catalog("<html>upstream error page</html>")
+
+    def test_non_list_payload_raises_parse_error(self):
+        with self.assertRaises(ParseError):
+            parse_catalog(json.dumps({"rows": []}))
+
+
+class FetchCatalogTests(unittest.TestCase):
+    def test_fetch_requests_the_catalogue_url(self):
+        client = FakeCatalogClient(json.dumps([ME_ROW]))
+
+        entries = fetch_catalog(client)
+
+        self.assertEqual(client.requested, [ANIME_LIST_URL])
+        self.assertEqual(len(entries), 1)
+
+
+class SearchCatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.entries = parse_catalog(json.dumps([ME_ROW, PW_ROW]))
+
+    def test_search_matches_substring(self):
+        matches = search_catalog(self.entries, "碧藍之海")
+
+        self.assertEqual([entry.anime_id for entry in matches], [1935])
+
+    def test_search_ignores_case(self):
+        self.assertEqual(len(search_catalog(self.entries, "grand blue")), 1)
+
+    def test_search_matches_pw_title_after_unwrapping(self):
+        matches = search_catalog(self.entries, "染谷同學")
+
+        self.assertEqual([entry.url for entry in matches], ["https://anime1.pw/?cat=62"])
+
+    def test_search_does_not_match_markup_stripped_from_titles(self):
+        self.assertEqual(search_catalog(self.entries, "href"), [])
+
+    def test_search_without_match_returns_empty_list(self):
+        self.assertEqual(search_catalog(self.entries, "no such anime"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,39 @@ class CliTests(unittest.TestCase):
         with patch("anicat.cli.search_main", side_effect=AssertionError("search should not run")):
             self.assertEqual(main(["--timeout", "0", "https://anime1.me/1"]), EXIT_USAGE)
 
+    def test_search_without_keyword_prompts_when_stdin_is_a_tty(self):
+        stdout = StringIO()
+
+        with (
+            patch.dict(os.environ, {"COLUMNS": "200"}),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="  碧藍之海  ") as prompt,
+            patch("anicat.cli.Anime1Client"),
+            patch("anicat.cli.fetch_catalog", return_value=[]),
+            redirect_stdout(stdout),
+            redirect_stderr(StringIO()),
+        ):
+            # No match is fine here; the point is that the prompt supplied the keyword.
+            self.assertEqual(main(["search"]), EXIT_FAILURE)
+
+        prompt.assert_called_once()
+
+    def test_search_without_keyword_does_not_prompt_when_stdin_is_not_a_tty(self):
+        with (
+            patch("sys.stdin.isatty", return_value=False),
+            patch("builtins.input", side_effect=AssertionError("input should not run")),
+            redirect_stderr(StringIO()),
+        ):
+            self.assertEqual(main(["search"]), EXIT_USAGE)
+
+    def test_search_with_blank_keyword_returns_usage_error(self):
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", return_value="   "),
+            redirect_stderr(StringIO()),
+        ):
+            self.assertEqual(main(["search", "   "]), EXIT_USAGE)
+
     def test_exit_code_constants_match_documented_values(self):
         self.assertEqual(EXIT_OK, 0)
         self.assertEqual(EXIT_FAILURE, 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
@@ -74,6 +75,8 @@ class CliTests(unittest.TestCase):
         stdout = StringIO()
 
         with (
+            # Pin the render width so table wrapping cannot break these assertions.
+            patch.dict(os.environ, {"COLUMNS": "200"}),
             patch("anicat.cli.Anime1Client"),
             patch("anicat.cli.fetch_catalog", return_value=entries),
             redirect_stdout(stdout),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from unittest.mock import patch
 
-from anicat import __version__
+from anicat import AnimeEntry, __version__
 from anicat.cli import EXIT_FAILURE, EXIT_OK, EXIT_USAGE, build_parser, main, options_from_args
 
 
@@ -58,6 +58,44 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(args.verbose, 0)
         self.assertTrue(args.quiet)
+
+    def test_search_subcommand_prints_titles_and_category_urls(self):
+        entries = [
+            AnimeEntry(
+                anime_id=1935,
+                title="GRAND BLUE 碧藍之海 第三季",
+                episodes="連載中(07)",
+                year="2026",
+                season="夏",
+                subtitle_group="",
+                url="https://anime1.me/?cat=1935",
+            )
+        ]
+        stdout = StringIO()
+
+        with (
+            patch("anicat.cli.Anime1Client"),
+            patch("anicat.cli.fetch_catalog", return_value=entries),
+            redirect_stdout(stdout),
+        ):
+            self.assertEqual(main(["search", "碧藍之海"]), EXIT_OK)
+
+        output = stdout.getvalue()
+        self.assertIn("GRAND BLUE 碧藍之海 第三季", output)
+        self.assertIn("https://anime1.me/?cat=1935", output)
+        self.assertIn("1 result(s)", output)
+
+    def test_search_without_match_returns_failure(self):
+        with (
+            patch("anicat.cli.Anime1Client"),
+            patch("anicat.cli.fetch_catalog", return_value=[]),
+            redirect_stderr(StringIO()),
+        ):
+            self.assertEqual(main(["search", "no such anime"]), EXIT_FAILURE)
+
+    def test_non_search_first_argument_still_uses_the_download_parser(self):
+        with patch("anicat.cli.search_main", side_effect=AssertionError("search should not run")):
+            self.assertEqual(main(["--timeout", "0", "https://anime1.me/1"]), EXIT_USAGE)
 
     def test_exit_code_constants_match_documented_values(self):
         self.assertEqual(EXIT_OK, 0)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -57,6 +57,17 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(source_kind("https://anime1.me/15651"), "anime1_me")
         self.assertEqual(source_kind("https://anime1.pw/349"), "anime1_pw")
 
+    def test_anime1_me_category_query_is_a_season_url(self):
+        # The catalogue index links seasons as ?cat=N rather than /category/...
+        self.assertTrue(is_season_url("https://anime1.me/?cat=1935"))
+        self.assertTrue(is_season_url("https://anime1.me/?cat=1935&paged=2"))
+        ensure_supported_url("https://anime1.me/?cat=1935")
+
+    def test_anime1_me_episode_path_wins_over_category_query(self):
+        self.assertFalse(is_season_url("https://anime1.me/28979?cat=1935"))
+        self.assertTrue(is_episode_url("https://anime1.me/28979?cat=1935"))
+        self.assertFalse(is_season_url("https://anime1.me/?cat=abc"))
+
     def test_rejects_unsupported_urls(self):
         with self.assertRaises(AniCatError):
             ensure_supported_url("https://example.com/15651")


### PR DESCRIPTION
## 動機

下載前必須自己開瀏覽器、找到番劇、複製 `?cat=1846` 這種網址。Anime1 自己就有目錄索引 `animelist.json`（1913 筆），拿來做搜尋就能補掉這個缺口。

## 使用方式

```bash
$ anicat search 碧藍之海
GRAND BLUE 碧藍之海 第三季 [連載中(07) · 2026 夏]
  -> https://anime1.me/?cat=1935
GRAND BLUE 碧藍之海 第二季 [1-12 · 2025 夏 · 悠哈璃羽]
  -> https://anime1.me/?cat=1708
碧藍之海 [1-12 · 2018 夏 · 悠哈璃羽&西農YUI]
  -> https://anime1.me/?cat=388
+ 3 result(s)
```

印出的網址直接餵回 `anicat` 就能下載整季。

## 順帶修掉一個既有 bug

`is_season_url` 對 `anime1.me` **只認 `/category/` 路徑**，但 Anime1 目錄索引用的全是 `?cat=N` —— 也就是說官方目錄頁的連結形式一直不被接受。`anime1.pw` 分支早就處理了同樣的 query 形式，這次讓兩者一致。

Episode path 仍然優先，所以 `/28979?cat=1935` 依舊判定為單集而非季度。

## 相容性

**沒有 breaking change。** `search` 是在 `main()` 裡先做字串 dispatch，不是改成 argparse subparsers，所以 `anicat <url>` 與所有既有參數完全未動。`test_non_search_first_argument_still_uses_the_download_parser` 守住這個行為。

## anime1.pw 條目的處理

上游用 `ID = 0` 當 anime1.pw 的哨兵值，這些 row 的標題欄位存的是 `<a href="...">標題</a>` 而非純標題。解析時會從 markup 取出標題與真實 URL，避免把 HTML 直接印給使用者。

## 設計取捨

- 不做快取 —— 單次 130 KB GET，複用既有 `Anime1Client` 的 retry/timeout
- 不引入 pandas / CSV —— 這是下載器不是資料倉儲，`json.loads` 就夠
- 搜尋只比對標題，沒加 `--year` / `--season` / `--limit`
- 壞掉的 row 略過並記 warning，不讓一筆髒資料炸掉整個搜尋

## 驗證

| 項目 | 結果 |
|---|---|
| `ruff format --check` | 28 files already formatted |
| `ruff check` | All checks passed |
| `pyright` | 0 errors, 0 warnings |
| `python -m unittest` | 88 tests OK（新增 19） |
| 實跑 `.me` 搜尋 | 3 筆 |
| 實跑 `.pw` 搜尋 | 1 筆，HTML 已剝除 |
| 無相符 | exit 1 |
| 端到端 | `?cat=1935` → 7 集、`?cat=62` → 4 集，可餵回下載管線 |
