### PR TITLE
fix: report the real package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - `anime1.me` 的 `?cat=N` 分類 URL 先前被判定為不支援，但那正是 Anime1 目錄索引使用的連結形式；現已與 `anime1.pw` 的判斷邏輯一致。
+- `__version__` 停留在 `0.1.0` 而 package 已是 `0.2.0`，導致 `anicat --version` 回報錯誤版本；並新增測試比對 distribution metadata 防止再次漂移。
 - 分類頁 HTML 無法解析出 episode link 時改為回報 `ParseError`，避免 selector 失效時 silent 回傳 0 集。
 
 ## 0.1.0 - 2026-05-24

--- a/src/anicat/__init__.py
+++ b/src/anicat/__init__.py
@@ -24,6 +24,6 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import importlib.resources
 import unittest
 
@@ -30,6 +31,11 @@ class PublicApiTests(unittest.TestCase):
         self.assertIs(anicat.FetchError, FetchError)
         self.assertIs(anicat.JobReport, JobReport)
         self.assertIs(anicat.ParseError, ParseError)
+
+    def test_version_matches_distribution_metadata(self):
+        # Guards against __version__ drifting from pyproject, which silently
+        # made `anicat --version` report a stale number.
+        self.assertEqual(anicat.__version__, importlib.metadata.version("anicat-v2"))
 
     def test_package_declares_typed_marker(self):
         marker = importlib.resources.files("anicat").joinpath("py.typed")


### PR DESCRIPTION
__version__ stayed at 0.1.0 after the package moved to 0.2.0, so
`anicat --version` reported a stale number to everyone running the
released build.

Pin the value to the distribution metadata in a test so the two cannot
drift apart again silently.
