### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,35 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-19
+
 ### Added
 
 - 新增 `anicat search KEYWORD` 子指令：查詢 Anime1 目錄索引並印出可直接下載的分類 URL，不必自行到網站複製網址；結果以 Rich table 呈現，URL 欄位固定寬度確保任何終端寬度都不會被裁切。
 - 新增 `anicat.catalog` 模組（`fetch_catalog` / `search_catalog` / `parse_catalog`）與 `AnimeEntry` model，並由 root package re-export `AnimeEntry`。
-- 支援 `anime1.pw` 單集、`?cat=` 分類頁與 slug 分類頁下載；此來源直接解析頁面 MP4 source，沿用現有 Range 續傳下載流程。
 
 ### Changed
 
 - 省略必要參數時的互動提問邏輯抽成共用 helper，`anicat` 與 `anicat search` 行為一致：TTY 下提問，非互動環境直接回報 usage error 而非卡住。
-- `anime1.pw` 頁面解析改用 GET 抓取 HTML，避免依賴 WordPress / Cloudflare 對 POST 頁面請求的相容行為。
-- direct video parser 會優先選擇 `video/mp4` source；若頁面提供多個 source 會記錄 warning。
 
 ### Fixed
 
 - `anime1.me` 的 `?cat=N` 分類 URL 先前被判定為不支援，但那正是 Anime1 目錄索引使用的連結形式；現已與 `anime1.pw` 的判斷邏輯一致。
 - `__version__` 停留在 `0.1.0` 而 package 已是 `0.2.0`，導致 `anicat --version` 回報錯誤版本；並新增測試比對 distribution metadata 防止再次漂移。
+
+## 0.2.0 - 2026-05-25
+
+### Added
+
+- 支援 `anime1.pw` 單集、`?cat=` 分類頁與 slug 分類頁下載；此來源直接解析頁面 MP4 source，沿用現有 Range 續傳下載流程。
+
+### Changed
+
+- `anime1.pw` 頁面解析改用 GET 抓取 HTML，避免依賴 WordPress / Cloudflare 對 POST 頁面請求的相容行為。
+- direct video parser 會優先選擇 `video/mp4` source；若頁面提供多個 source 會記錄 warning。
+
+### Fixed
+
 - 分類頁 HTML 無法解析出 episode link 時改為回報 `ParseError`，避免 selector 失效時 silent 回傳 0 集。
 
 ## 0.1.0 - 2026-05-24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anicat-v2"
-version = "0.2.0"
+version = "0.3.0"
 description = "Anime1 downloader CLI with resumable concurrent downloads."
 authors = [
     {name = "HeiTang",email = "heitang.me@gmail.com"}

--- a/src/anicat/__init__.py
+++ b/src/anicat/__init__.py
@@ -24,6 +24,6 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
## 內容

發布 0.3.0，主要是新增 `anicat search` 子指令。

```
pyproject.toml          version = "0.2.0"  ->  "0.3.0"
src/anicat/__init__.py  __version__ = "0.2.0"  ->  "0.3.0"
CHANGELOG.md            收尾 + 補回遺漏的 0.2.0 區塊
```

版號選 minor 而非 patch，因為新增了對外的子指令。

## 順帶修正 CHANGELOG 的歷史帳

原本的 CHANGELOG 從 `## Unreleased` 直接跳到 `## 0.1.0` —— **`0.2.0` 的區塊從來沒被建立過**。

用 `git show v0.2.0:CHANGELOG.md` 檢查當時 tag 上的檔案，確認 v0.2.0 發布時忘了把 `Unreleased` 收成版本區塊，所以那三筆 `anime1.pw` 的變更（2026-05-25 就出貨了）一直掛在 `Unreleased` 底下。

如果照一般作法直接把整個 `Unreleased` 收成 `0.3.0`，會**把三個月前就發布的功能錯標成今天的新功能**。所以這次拆成兩段：

```
## Unreleased          ← 空的，給下一輪
## 0.3.0 - 2026-08-19  ← search 子指令、catalog 模組、prompt helper、?cat= 修正、__version__ 修正
## 0.2.0 - 2026-05-25  ← 補回來：anime1.pw 支援（對照 v0.2.0 tag 的內容還原）
## 0.1.0 - 2026-05-24
```

## 0.3.0 收錄的變更

**Added**
- `anicat search KEYWORD` 子指令（#8）
- `anicat.catalog` 模組與 `AnimeEntry` model（#8）

**Changed**
- 省略必要參數時的互動提問抽成共用 helper，`anicat` 與 `anicat search` 行為一致（#8）

**Fixed**
- `anime1.me` 的 `?cat=N` 分類 URL 先前被判定為不支援（#8）
- `__version__` 停留在 `0.1.0` 導致 `anicat --version` 回報錯誤版本（#9）

CI 的 actions 升級（#11）不列入 CHANGELOG —— runner 的 node 版本不影響套件使用者，CHANGELOG 記錄的是使用者感知得到的變化。

## 驗證

| 項目 | 結果 |
|---|---|
| `ruff format --check` | 28 files already formatted |
| `ruff check` | All checks passed |
| `pyright` | 0 errors, 0 warnings |
| `python -m unittest` | 92 tests OK（2 skipped 為 opt-in smoke） |
| `anicat --version` | `0.3.0` |
| distribution metadata | `0.3.0` |

兩處版本號被 #9 新增的守衛綁在一起（比對 `importlib.metadata.version`），任一邊漏改會直接讓測試失敗 —— 這次它確實起了作用。

## Merge 後

打 tag 發 release v0.3.0，release notes 取自本次新增的 `## 0.3.0` 區塊。
