### PR TITLE
ci: bump actions off the deprecated node20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Poetry
         run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry


### PR DESCRIPTION
## 問題

每一次 CI 執行都會在 annotation 區印出這行：

```
! Node.js 20 is deprecated. The following actions target Node.js 20 but are being
  forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5.
```

`actions/checkout@v4` 與 `actions/setup-python@v5` 的 runtime 宣告是 node20。GitHub 目前的處置是**強制拉到 node24 執行並印警告**，所以現在還能跑 —— 但這是過渡期行為，不是穩定狀態。等 GitHub 收掉相容層，CI 會直接壞。

## 變更

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7

-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
```

兩者的最新版都是 v7（`checkout` v7.0.1、`setup-python` v7.0.0），runtime 直接宣告 node24。

v5 → v7 之間各版的 release notes 中，唯一的 breaking change 就是 runtime 版本推進（node16 → node20 → node24）。本 repo 用 `runs-on: ubuntu-latest`，GitHub-hosted runner 一律是最新版，不受影響。

## 相容性

`setup-python` 的 cache 相關 input 在 v5 → v7 之間沒有變動，所以既有設定原封不動繼續有效：

```yaml
with:
  python-version: ${{ matrix.python-version }}
  cache: poetry
  cache-dependency-path: poetry.lock
```

Workflow 的其他部分完全沒動 —— 觸發器、3.12/3.13 matrix、10 個 step 都不變。已用嚴格 YAML parser 驗證過解析結果：

```
triggers: ['push', 'pull_request']
matrix: ['3.12', '3.13']
steps: 10
uses: ['actions/checkout@v7', 'actions/setup-python@v7']
```

## 驗證方式

`ruff` / `pyright` / `unittest` 對這個改動沒有意義 —— **這個 PR 的驗證就是 CI 自己跑起來**。要看兩件事：

1. 兩個 job（3.12 / 3.13）都通過
2. **那行 node20 deprecation 警告從 annotation 消失**

第 2 點才是這次改動的目的。只有 job 綠不算數，因為改之前它也是綠的。

## 為什麼不併進 release PR

`release/0.3.0`（#10）應該只做版本號與 CHANGELOG 的事。CI runner 的 node 版本不影響套件使用者，因此本 PR 也**不加 CHANGELOG 條目** —— CHANGELOG 記錄的是使用者感知得到的變化。

兩個 PR 沒有檔案重疊（本 PR 只動 `.github/workflows/ci.yml`），所以 #10 不需要 rebase。

## 相關

同樣的問題在 `Anime1-Data` 已於今日一併處理（該 repo 原本停留在更舊的 `@v2` / node16）。
