### PR TITLE
test: cover the season crawl and run smoke tests weekly

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,36 @@
+name: Smoke
+
+# Kept separate from CI on purpose: this workflow talks to Anime1, so it turns
+# red when the upstream site changes or goes down. Mixing that signal into the
+# PR gate would train everyone to ignore a red check.
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: poetry
+          cache-dependency-path: poetry.lock
+
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction
+
+      - name: Run Anime1 smoke tests
+        env:
+          ANICAT_RUN_INTEGRATION: "1"
+          ANICAT_RUN_PW_INTEGRATION: "1"
+        run: poetry run python -m unittest tests.test_integration_smoke -v

--- a/tests/test_integration_smoke.py
+++ b/tests/test_integration_smoke.py
@@ -1,13 +1,27 @@
 import os
 import unittest
 
+from anicat.catalog import fetch_catalog
 from anicat.client import Anime1Client
-from anicat.extractor import Anime1Extractor
+from anicat.extractor import Anime1Extractor, parse_season_page
+from anicat.urls import is_episode_url
 
 RUN_INTEGRATION = os.environ.get("ANICAT_RUN_INTEGRATION") == "1"
 RUN_PW_INTEGRATION = os.environ.get("ANICAT_RUN_PW_INTEGRATION") == "1"
 SMOKE_URL = os.environ.get("ANICAT_SMOKE_URL", "https://anime1.me/28979")
 PW_SMOKE_URL = os.environ.get("ANICAT_PW_SMOKE_URL", "https://anime1.pw/349")
+# Left empty on purpose: the season URL is derived from the live catalogue so it
+# cannot go stale the way a pinned category would.
+SMOKE_SEASON_URL = os.environ.get("ANICAT_SMOKE_SEASON_URL", "")
+
+
+def current_season_url(client: Anime1Client) -> str:
+    """Return the season category URL of the newest entry in the catalogue."""
+
+    if SMOKE_SEASON_URL:
+        return SMOKE_SEASON_URL
+    newest = next(entry for entry in fetch_catalog(client) if entry.anime_id)
+    return f"https://anime1.me/category/{newest.year}年{newest.season}季"
 
 
 @unittest.skipUnless(RUN_INTEGRATION, "set ANICAT_RUN_INTEGRATION=1 to run Anime1 smoke tests")
@@ -34,6 +48,22 @@ class Anime1SmokeTests(unittest.TestCase):
                 self.assertEqual(len(body), 2)
             finally:
                 response.close()
+        finally:
+            client.close()
+
+    def test_season_crawl_follows_pagination(self):
+        # The episode test never touches the season selectors, so an upstream
+        # layout change would otherwise break whole-season downloads silently.
+        client = Anime1Client(timeout=(10.0, 30.0), retries=1)
+        try:
+            season_url = current_season_url(client)
+            first_page = parse_season_page(client.post_page(season_url))
+            all_urls = Anime1Extractor(client).season_episode_urls(season_url)
+
+            self.assertTrue(first_page.episode_urls)
+            self.assertIsNotNone(first_page.next_url)
+            self.assertGreater(len(all_urls), len(first_page.episode_urls))
+            self.assertTrue(all(is_episode_url(url) for url in all_urls))
         finally:
             client.close()
 


### PR DESCRIPTION
## 問題一：整季下載完全沒有 smoke test 守著

現有的 smoke test 只解析一集，覆蓋到的是單集頁的 selector。季度爬取依賴的另外兩個 selector **零覆蓋**：

| `extractor.py` | selector | 原本有測嗎 |
|---|---|---|
| `parse_episode_page` | `h2.entry-title`、`video.video-js[data-apireq]` | ✅ |
| `parse_season_page` | `h2.entry-title a[rel='bookmark']` | ❌ |
| `parse_season_page` | `div.nav-previous a[href]` | ❌ |

也就是說 Anime1 改版時，**單集下載會叫、整季下載會靜默壞掉** —— 而整季才是使用者最常用的入口。

## 問題二：smoke test 從來沒被執行過

`tests/test_integration_smoke.py` 自寫成以來就是雙重 opt-in：

```python
RUN_INTEGRATION = os.environ.get("ANICAT_RUN_INTEGRATION") == "1"
RUN_PW_INTEGRATION = os.environ.get("ANICAT_RUN_PW_INTEGRATION") == "1"
```

CI 沒有設過這兩個變數，所以它們一直是 skip。結果是：**就算 anime1.me 整站蒸發，CI 依然全綠。** 測試寫好了卻沒有接上。

## 變更

### 1. 新增季度爬取的 smoke test

```python
season_url = current_season_url(client)
first_page = parse_season_page(client.post_page(season_url))
all_urls = Anime1Extractor(client).season_episode_urls(season_url)

self.assertTrue(first_page.episode_urls)
self.assertIsNotNone(first_page.next_url)
self.assertGreater(len(all_urls), len(first_page.episode_urls))
self.assertTrue(all(is_episode_url(url) for url in all_urls))
```

拿完整爬取的結果與第一頁比較，**證明分頁真的被跟隨了**，而不是假設它有效。沒有用魔術數字。

### 2. 季度 URL 不寫死，從目錄索引推導

```python
newest = next(entry for entry in fetch_catalog(client) if entry.anime_id)
return f"https://anime1.me/category/{newest.year}年{newest.season}季"
```

寫死 `2026年夏季` 這種網址三個月後就會過期，變成誤報。改成取目錄索引最新一筆的年份與季節組出來，季度換了會自動跟上。副作用是順便覆蓋了 catalogue 路徑。

需要覆寫時仍可用 `ANICAT_SMOKE_SEASON_URL`。

> 註：`?cat=N` 這種單一作品的分類頁**不會分頁**（整部作品的集數在同一頁），只有 `/category/季度` 這種整季彙整頁才會。所以要覆蓋 `nav-previous` 必須用後者。

### 3. 新增 weekly smoke workflow

```yaml
on:
  schedule:
    - cron: "0 3 * * 1"
  workflow_dispatch:
```

**刻意不併進 `ci.yml`。** 這支會打真實網站，anime1.me 掛掉或改版時它就會紅 —— 那個訊號混進擋 PR 的 CI 只會訓練大家忽略紅燈。分開之後兩種紅燈語意清楚：

- `CI` 紅 → 你的 code 有問題
- `Smoke` 紅 → 上游變了

## 驗證

**實際對真實上游跑過**，不是只確認 skip 邏輯：

```
$ ANICAT_RUN_INTEGRATION=1 ANICAT_RUN_PW_INTEGRATION=1 poetry run python -m unittest tests.test_integration_smoke -v

test_direct_video_source_supports_resume_contract ... ok
test_episode_range_request_supports_resume_contract ... ok
test_season_crawl_follows_pagination ... ok

Ran 3 tests in 38.788s
OK
```

季度爬取實測抓到 **403 集、約 29 個請求、20 秒**。週跑一次的成本可忽略。

一般 CI 不受影響（smoke 仍預設 skip）：

| 項目 | 結果 |
|---|---|
| `ruff format --check` | 28 files already formatted |
| `ruff check` | All checks passed |
| `pyright` | 0 errors, 0 warnings |
| `python -m unittest` | 93 tests OK（3 skipped 為 opt-in smoke） |

## 已知限制

`anime1.pw` 的季度爬取仍未覆蓋 —— 該來源的 slug 分類頁分頁行為未驗證。本 PR 先處理 `anime1.me`，因為那是主要路徑。
